### PR TITLE
expose debugging flag to CLI

### DIFF
--- a/src/nwb_benchmarks/command_line_interface.py
+++ b/src/nwb_benchmarks/command_line_interface.py
@@ -12,6 +12,9 @@ def main():
         return
 
     command = sys.argv[1]
+    flags_list = sys.argv[2:]
+
+    debug_mode = "--debug" in flags_list
 
     if command == "run":
         commit_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("ascii").strip()
@@ -24,6 +27,8 @@ def main():
             "--set-commit-hash",
             commit_hash,
         ]
+        if debug_mode:
+            cmd.extend(["--verbose", "--show-std-err"])
 
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE)  # , bufsize=1)
         encoding = locale.getpreferredencoding()  # This is how ASV chooses to encode the output

--- a/src/nwb_benchmarks/command_line_interface.py
+++ b/src/nwb_benchmarks/command_line_interface.py
@@ -32,6 +32,8 @@ def main():
         ]
         if debug_mode:
             cmd.extend(["--verbose", "--show-std-err"])
+        if bench_mode:
+            cmd.extend(["--bench", specific_benchmark_pattern])
 
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE)  # , bufsize=1)
         encoding = locale.getpreferredencoding()  # This is how ASV chooses to encode the output

--- a/src/nwb_benchmarks/command_line_interface.py
+++ b/src/nwb_benchmarks/command_line_interface.py
@@ -15,6 +15,9 @@ def main():
     flags_list = sys.argv[2:]
 
     debug_mode = "--debug" in flags_list
+    bench_mode = "--bench" in flags_list
+    if bench_mode:
+        specific_benchmark_pattern = flags_list[flags_list.index("--bench")+1]
 
     if command == "run":
         commit_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("ascii").strip()


### PR DESCRIPTION
relevant but does not close #4 

@oruebel Per your question on debugging #5 in the run command, this adds a CLI flag `--debug` that show display tracebacks

NOTE 1: that relies on the tracebacks actually triggering due to an error in the test case itself - I don't think it capture errors in the `setup`

NOTE 2: for the internet dependent tests, and this is especially prevalent for `fsspec` on my device, the tests can show up as 'failed' without any traceback if they hit the maximum `timeout` value. This can be configured per test I believe, as an attribute on the class similar to the `repeat` value (which if the test is expected to take a long time, you might want to limit anyway)