### PR TITLE
Improvements to debugging and minor changes

### DIFF
--- a/docs/running_benchmarks.rst
+++ b/docs/running_benchmarks.rst
@@ -12,11 +12,11 @@ use `psutil net_connections <https://psutil.readthedocs.io/en/latest/#psutil.net
 
 .. code-block::
 
-    sudo nwb_benchmarks run
+    sudo -E nwb_benchmarks run
 
 Or drop the ``sudo`` if on Windows.
 
-When running on Windows or if ``tshark`` is not installed on the path, then may also need to set the ``TSHARK_PATH`` environment variable beforehand, which should be the absolute path to the ``tshark`` executable (e.g., ``tshark.exe``) on your system.
+When running on Windows or if ``tshark`` is not installed on the path, then you may also need to set the ``TSHARK_PATH`` environment variable beforehand, which should be the absolute path to the ``tshark`` executable (e.g., ``tshark.exe``) on your system.
 
 Many of the current tests can take several minutes to complete; the entire suite will take many times that. Grab some coffee, read a book, or better yet (when the suite becomes larger) just leave it to run overnight.
 

--- a/docs/running_benchmarks.rst
+++ b/docs/running_benchmarks.rst
@@ -48,6 +48,11 @@ If you want to get a full traceback to examine why a new test might be failing, 
 
     nwb_benchmarks run --debug
 
+Setting this flag will also override the `repeat` parameter of benchmarks and set it to 1, so that you can quickly
+iterate on the code and see the results of your changes without having to wait for the full suite to run.
+
+Setting this flag will also not write results to the local cached results directory or upload results to the central
+database automatically.
 
 Contributing Results
 --------------------

--- a/environments/nwb_benchmarks.yaml
+++ b/environments/nwb_benchmarks.yaml
@@ -11,6 +11,7 @@ dependencies:
       - psutil
       - dandi
       - fsspec
+      - s3fs
       - requests
       - aiohttp
       - remfile

--- a/src/nwb_benchmarks/__init__.py
+++ b/src/nwb_benchmarks/__init__.py
@@ -1,7 +1,22 @@
 """Outermost exposed imports; including global environment variables."""
 
 import os
+import shutil
+import warnings
 
 from .command_line_interface import main
 
+# Determine the path for running tshark
 TSHARK_PATH = os.environ.get("TSHARK_PATH", None)
+if TSHARK_PATH is None:
+    TSHARK_PATH = shutil.which("tshark")
+
+if TSHARK_PATH is None:
+    warnings.warn("tshark not found. Set TSHARK_PATH in the environment or install tshark on the default path.")
+else:
+    print(f"Using tshark at: {TSHARK_PATH}")
+
+__all__ = [
+    "main",
+    "TSHARK_PATH",
+]

--- a/src/nwb_benchmarks/benchmarks/network_tracking_remote_file_reading.py
+++ b/src/nwb_benchmarks/benchmarks/network_tracking_remote_file_reading.py
@@ -254,13 +254,13 @@ class NWBLindiFileCreateLocalReferenceFileSystemBenchmark(BaseBenchmark):
         if os.path.exists(self.lindi_file):
             os.remove(self.lindi_file)
 
-    def track_network_activity_create_lindi_referernce_file_system(self, s3_url: str):
+    def track_network_activity_create_lindi_reference_file_system(self, s3_url: str):
         """Create a local Lindi JSON reference filesystem from a remote HDF5 file"""
         with network_activity_tracker(tshark_path=TSHARK_PATH) as network_tracker:
             create_lindi_reference_file_system(s3_url=s3_url, outfile_path=self.lindi_file)
         return network_tracker.asv_network_statistics
 
-    def track_network_activity_create_lindi_referernce_file_system_and_read_nwbfile(self, s3_url: str):
+    def track_network_activity_create_lindi_reference_file_system_and_read_nwbfile(self, s3_url: str):
         """
         Create a local Lindi JSON reference filesystem from a remote HDF5 file
         and then read the NWB file with PyNWB using LINDI with the local JSON

--- a/src/nwb_benchmarks/benchmarks/time_remote_file_reading.py
+++ b/src/nwb_benchmarks/benchmarks/time_remote_file_reading.py
@@ -196,11 +196,11 @@ class NWBLindiFileCreateLocalReferenceFileSystemBenchmark(BaseBenchmark):
         if os.path.exists(self.lindi_file):
             os.remove(self.lindi_file)
 
-    def time_create_lindi_referernce_file_system(self, s3_url: str):
+    def time_create_lindi_reference_file_system(self, s3_url: str):
         """Create a local Lindi JSON reference filesystem from a remote HDF5 file"""
         create_lindi_reference_file_system(s3_url=s3_url, outfile_path=self.lindi_file)
 
-    def time_create_lindi_referernce_file_system_and_read_nwbfile(self, s3_url: str):
+    def time_create_lindi_reference_file_system_and_read_nwbfile(self, s3_url: str):
         """
         Create a local Lindi JSON reference filesystem from a remote HDF5 file
         and then read the NWB file with PyNWB using LINDI with the local JSON
@@ -208,7 +208,7 @@ class NWBLindiFileCreateLocalReferenceFileSystemBenchmark(BaseBenchmark):
         create_lindi_reference_file_system(s3_url=s3_url, outfile_path=self.lindi_file)
         self.nwbfile, self.io, self.client = read_hdf5_nwbfile_lindi(rfs=self.lindi_file)
 
-    def time_create_lindi_referernce_file_system_and_read_jsonrfs(self, s3_url: str):
+    def time_create_lindi_reference_file_system_and_read_jsonrfs(self, s3_url: str):
         """
         Create a local Lindi JSON reference filesystem  from a remote HDF5 file and
         then read the HDF5 file with LINDI using the local JSON.

--- a/src/nwb_benchmarks/command_line_interface.py
+++ b/src/nwb_benchmarks/command_line_interface.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import sys
 
-from .core import upload_results, clean_results
+from .core import clean_results, upload_results
 from .setup import customize_asv_machine_file, reduce_results
 
 
@@ -95,7 +95,7 @@ def main() -> None:
         else:
             reduce_results(
                 raw_results_file_path=raw_results_file_path,
-                raw_environment_info_file_path=raw_environment_info_file_path
+                raw_environment_info_file_path=raw_environment_info_file_path,
             )
             upload_results()
     elif command == "upload":

--- a/src/nwb_benchmarks/command_line_interface.py
+++ b/src/nwb_benchmarks/command_line_interface.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import sys
 
-from .core import upload_results
+from .core import upload_results, clean_results
 from .setup import customize_asv_machine_file, reduce_results
 
 
@@ -66,7 +66,7 @@ def main() -> None:
             commit_hash,
         ]
         if debug_mode:
-            cmd.extend(["--verbose", "--show-stderr"])
+            cmd.extend(["--verbose", "--show-stderr", "--attribute", "repeat=1"])
         if bench_mode:
             cmd.extend(["--bench", specific_benchmark_pattern])
 
@@ -90,13 +90,18 @@ def main() -> None:
         assert len(globbed_json_file_paths) == 1, "A single intermediate result was not found, please raise an issue."
         raw_results_file_path = globbed_json_file_paths[0]
 
-        reduce_results(
-            raw_results_file_path=raw_results_file_path, raw_environment_info_file_path=raw_environment_info_file_path
-        )
-
-        upload_results()
+        if debug_mode:
+            raw_results_file_path.unlink()
+        else:
+            reduce_results(
+                raw_results_file_path=raw_results_file_path,
+                raw_environment_info_file_path=raw_environment_info_file_path
+            )
+            upload_results()
     elif command == "upload":
         upload_results()
+    elif command == "clean":
+        clean_results()
     else:
         print(f"{command} is an invalid command.")
 

--- a/src/nwb_benchmarks/command_line_interface.py
+++ b/src/nwb_benchmarks/command_line_interface.py
@@ -1,16 +1,10 @@
 """Simple wrapper around `asv run` for convenience."""
 
-import json
 import locale
-import os
 import pathlib
 import shutil
 import subprocess
 import sys
-import time
-import warnings
-
-import requests
 
 from .core import upload_results
 from .setup import customize_asv_machine_file, reduce_results

--- a/src/nwb_benchmarks/core/__init__.py
+++ b/src/nwb_benchmarks/core/__init__.py
@@ -25,7 +25,7 @@ from ._streaming import (
     read_zarr_nwbfile,
     robust_ros3_read,
 )
-from ._upload import upload_results
+from ._results import upload_results, clean_results
 
 __all__ = [
     "BaseBenchmark",
@@ -52,4 +52,5 @@ __all__ = [
     "read_zarr",
     "read_zarr_nwbfile",
     "upload_results",
+    "clean_results",
 ]

--- a/src/nwb_benchmarks/core/__init__.py
+++ b/src/nwb_benchmarks/core/__init__.py
@@ -7,6 +7,7 @@ from ._network_profiler import NetworkProfiler
 from ._network_statistics import NetworkStatistics
 from ._network_tracker import network_activity_tracker
 from ._nwb_helpers import get_object_by_name
+from ._results import clean_results, upload_results
 from ._streaming import (
     create_lindi_reference_file_system,
     read_hdf5_fsspec_no_cache,
@@ -25,7 +26,6 @@ from ._streaming import (
     read_zarr_nwbfile,
     robust_ros3_read,
 )
-from ._results import upload_results, clean_results
 
 __all__ = [
     "BaseBenchmark",

--- a/src/nwb_benchmarks/core/_results.py
+++ b/src/nwb_benchmarks/core/_results.py
@@ -5,10 +5,16 @@ import warnings
 
 import requests
 
+RESULTS_CACHE_DIR = pathlib.Path.home() / ".cache" / "nwb_benchmarks" / "results"
+
+
+def clean_results():
+    for results_file_path in RESULTS_CACHE_DIR.rglob(pattern="*.json"):
+        results_file_path.unlink(missing_ok=True)
+
 
 def upload_results():
-    results_cache_directory = pathlib.Path.home() / ".cache" / "nwb_benchmarks" / "results"
-    for results_file_path in results_cache_directory.rglob(pattern="*.json"):
+    for results_file_path in RESULTS_CACHE_DIR.rglob(pattern="*.json"):
         with results_file_path.open("r") as file_stream:
             json_content = json.load(file_stream)
 
@@ -19,7 +25,7 @@ def upload_results():
             timeout=30,
         )
         if response.status_code == 200:
-            print(f"Results posted successfully!")
+            print(f"Results posted successfully! {filename}")
         else:
             message = (
                 "Failed to post results. "

--- a/src/nwb_benchmarks/setup/_reduce_results.py
+++ b/src/nwb_benchmarks/setup/_reduce_results.py
@@ -105,18 +105,21 @@ def reduce_results(raw_results_file_path: pathlib.Path, raw_environment_info_fil
 
     with open(file=parsed_results_file, mode="w") as io:
         json.dump(obj=reduced_results_info, fp=io, indent=1)  # At least one level of indent makes it easier to read
+    print("Results written to:         ", parsed_results_file.absolute())
 
     # Copy machine file to main results
     machine_info_file_path = raw_results_file_path.parent / "machine.json"
     machine_info_copy_file_path = results_cache_directory / f"info_machine-{machine_hash}.json"
     if not machine_info_copy_file_path.exists():
         shutil.copyfile(src=machine_info_file_path, dst=machine_info_copy_file_path)
+    print("Machine info written to:    ", machine_info_copy_file_path.absolute())
 
     # Save parsed environment info within machine subdirectory of .asv
     parsed_environment_file_path = results_cache_directory / f"info_environment-{environment_hash}.json"
     if not parsed_environment_file_path.exists():
         with open(file=parsed_environment_file_path, mode="w") as io:
             json.dump(obj=parsed_environment_info, fp=io, indent=1)
+    print("Environment info written to:", parsed_environment_file_path.absolute())
 
     # Network tests require admin permissions, which can alter write permissions of any files created
     if sys.platform in ["darwin", "linux"]:


### PR DESCRIPTION
- Adds tshark debugging changes from #77. 
- Enhances `--debug` mode to 
  - run only 1 repeat instead of the 3 specified in the current benchmarks
  - not write results to the results cache folder
  - not upload results
- This is all because I may be doing weird debugging/testing things on my local machine where I want to iterate quickly and do not want the results uploaded to the server.
- Adds/enhances print statements when reducing results and uploading results
- Adds command to clear the results cache folder (`sudo nwb_benchmarks clean`)
- Adds `s3fs` to the environment, which is needed for `time_remote_file_reading.DirectZarrFileReadBenchmark` (note the consolidated metadata benchmark still does not work due to issues in hdmf-zarr, I think)
- Fixes spelling of a couple benchmarks "referernce" -> "reference"

