### PR TITLE
Allow user to specify network interface to run tshark on

### DIFF
--- a/docs/running_benchmarks.rst
+++ b/docs/running_benchmarks.rst
@@ -7,16 +7,47 @@ Also, please ensure prior to running the benchmark that all code changes have be
 
 For the most stable results, only run the benchmarks on the ``main`` branch.
 
-To run the full benchmark suite, including network tracking tests (which require ``sudo`` on Mac and AIX platforms due to the
-use `psutil net_connections <https://psutil.readthedocs.io/en/latest/#psutil.net_connections>`_), simply call...
+To run the full benchmark suite, including network tracking tests (which require ``sudo`` on Mac and Linux platforms due to the
+use of `psutil net_connections <https://psutil.readthedocs.io/en/latest/#psutil.net_connections>`_), first determine which network
+interface you want to monitor (e.g., ``en0``, ``eth0``, etc.). You can typically find this information via your system settings,
+or by running commands like ``ifconfig`` or ``ip addr`` in your terminal. On Linux/MacOS, this command will return the default
+network interface name for internet connectivity:
+
+.. code-block::
+
+    route get default | awk '/interface:/{print $NF}'
+
+On Windows, in Powershell, you can use:
+
+.. code-block::
+
+    Get-NetAdapter | Where-Object {$_.Status -eq "Up"}
+
+and select the appropriate interface name from the output.
+
+Then, set the environment variable ``NWB_BENCHMARKS_NETWORK_INTERFACE`` to the desired network interface.
+For example, in a Unix-like terminal (Linux or macOS), you can do:
+
+.. code-block::
+
+    export NWB_BENCHMARKS_NETWORK_INTERFACE=en0
+
+On Windows, you can use:
+
+.. code-block::
+
+    $env:NWB_BENCHMARKS_NETWORK_INTERFACE="Ethernet"
+
+On Windows, or if ``tshark`` is not installed on the path, you may also need to set the ``TSHARK_PATH`` environment
+variable to the absolute path to the ``tshark`` executable (e.g., ``tshark.exe``) on your system.
+
+Then, simply call...
 
 .. code-block::
 
     sudo -E nwb_benchmarks run
 
 Or drop the ``sudo`` if on Windows.
-
-When running on Windows or if ``tshark`` is not installed on the path, then you may also need to set the ``TSHARK_PATH`` environment variable beforehand, which should be the absolute path to the ``tshark`` executable (e.g., ``tshark.exe``) on your system.
 
 Many of the current tests can take several minutes to complete; the entire suite will take many times that. Grab some coffee, read a book, or better yet (when the suite becomes larger) just leave it to run overnight.
 

--- a/src/nwb_benchmarks/__init__.py
+++ b/src/nwb_benchmarks/__init__.py
@@ -8,15 +8,20 @@ from .command_line_interface import main
 
 # Determine the path for running tshark
 TSHARK_PATH = os.environ.get("TSHARK_PATH", None)
+NETWORK_INTERFACE = os.environ.get("NWB_BENCHMARKS_NETWORK_INTERFACE", None)
+
 if TSHARK_PATH is None:
     TSHARK_PATH = shutil.which("tshark")
 
 if TSHARK_PATH is None:
     warnings.warn("tshark not found. Set TSHARK_PATH in the environment or install tshark on the default path.")
 else:
-    print(f"Using tshark at: {TSHARK_PATH}")
+    if NETWORK_INTERFACE is None:
+        warnings.warn("NWB_BENCHMARKS_NETWORK_INTERFACE not found. Set it in the environment.")
+    print(f"Using tshark at: {TSHARK_PATH} on {NETWORK_INTERFACE}")
 
 __all__ = [
     "main",
     "TSHARK_PATH",
+    "NETWORK_INTERFACE",
 ]

--- a/src/nwb_benchmarks/core/_network_profiler.py
+++ b/src/nwb_benchmarks/core/_network_profiler.py
@@ -50,6 +50,9 @@ class NetworkProfiler:
         """Start the capture with tshark in a subprocess."""
         tshark_path = tshark_path or "tshark"
         tsharkCall = [str(tshark_path), "-w", str(self.capture_file_path)]
+        networkInterface = os.environ.get("NWB_BENCHMARKS_NETWORK_INTERFACE")
+        if networkInterface:
+            tsharkCall.extend(["-i", networkInterface])
         self.__tshark_process = subprocess.Popen(tsharkCall, stderr=subprocess.DEVNULL)
         time.sleep(0.2)  # not sure if this is needed but just to be safe
 

--- a/src/nwb_benchmarks/core/_network_profiler.py
+++ b/src/nwb_benchmarks/core/_network_profiler.py
@@ -4,6 +4,7 @@ Class definition for capturing network traffic when remotely reading data from a
 NOTE: This requires sudo/root access on  macOS and AIX.
 """
 
+import os
 import pathlib
 import subprocess
 import tempfile


### PR DESCRIPTION
The default network interface that tshark selected for my machine was not the internet one, so no data was tracked. This PR allows the user to specify an environment variable `NWB_BENCHMARKS_NETWORK_INTERFACE` with the name of the interface, which will be different on each machine. It does not seem straightforward to set this automatically. I did not set this up so that users cannot run the benchmarks if they do not have this set. It will still use the default network interface in that case.