### PR TITLE
Fix conda list issue

### DIFF
--- a/src/nwb_benchmarks/command_line_interface.py
+++ b/src/nwb_benchmarks/command_line_interface.py
@@ -52,7 +52,7 @@ def main() -> None:
         # subprocess tends to have issues inheriting `conda` entrypoint
         raw_environment_info_file_path = asv_root / ".raw_environment_info.txt"
         with open(file=raw_environment_info_file_path, mode="w") as stdout:
-            environment_info_process = subprocess.Popen(args=["conda", "list"], stdout=stdout, shell=True)
+            environment_info_process = subprocess.Popen(args=["conda", "list"], stdout=stdout)
             environment_info_process.wait()
 
         if not raw_environment_info_file_path.exists():


### PR DESCRIPTION
Fix #123. `conda list` does not use any special shell commands so it's fine to not use `shell=True`.

Alternatively:
- `subprocess.Popen("conda list", stdout=stdout, shell=True)`
- `subprocess.run(["conda", "list"], stdout=stdout)`
