### PR TITLE
Replace read of remote LINDI with download, fix download call

### DIFF
--- a/src/nwb_benchmarks/benchmarks/network_tracking_remote_file_reading.py
+++ b/src/nwb_benchmarks/benchmarks/network_tracking_remote_file_reading.py
@@ -226,7 +226,7 @@ class LindiLocalJSONFileReadBenchmark(BaseBenchmark):
         """Download the LINDI JSON file."""
         self.lindi_file = os.path.basename(https_url) + ".lindi.json"
         self.teardown(https_url=https_url)
-        download_file(https_url=https_url, local_path=self.lindi_file)
+        download_file(url=https_url, local_path=self.lindi_file)
 
     def teardown(self, https_url: str):
         """Delete the LINDI JSON file if it exists."""
@@ -245,34 +245,6 @@ class LindiLocalJSONFileReadBenchmark(BaseBenchmark):
         """Read a remote HDF5 NWB file with pynwb using lindi with the local LINDI JSON file."""
         with network_activity_tracker(tshark_path=TSHARK_PATH) as network_tracker:
             self.nwbfile, self.io, self.client = read_hdf5_pynwb_lindi(rfs=self.lindi_file)
-        return network_tracker.asv_network_statistics
-
-
-class LindiRemoteJSONFileReadBenchmark(BaseBenchmark):
-    """
-    Track the network activity during read of remote HDF5 files by reading the remote LINDI JSON files with lindi and
-    h5py or pynwb.
-
-    Note: When LINDI is pointed to a remote JSON, it starts by downloading it, so the network activity should not be
-    that different from the activity to download the remote JSON and load the local JSON.
-
-    Note: in all cases, store the in-memory objects to be consistent with timing benchmarks.
-    """
-
-    parameter_cases = lindi_remote_rfs_parameter_cases
-
-    @skip_benchmark_if(TSHARK_PATH is None)
-    def track_network_read_lindi_h5py(self, https_url: str):
-        """Read a remote HDF5 file with h5py using lindi with the remote LINDI JSON file."""
-        with network_activity_tracker(tshark_path=TSHARK_PATH) as network_tracker:
-            self.client = read_hdf5_h5py_lindi(rfs=https_url)
-        return network_tracker.asv_network_statistics
-
-    @skip_benchmark_if(TSHARK_PATH is None)
-    def track_network_read_lindi_pynwb(self, https_url: str):
-        """Read a remote HDF5 NWB file with pynwb using lindi with the remote LINDI JSON file."""
-        with network_activity_tracker(tshark_path=TSHARK_PATH) as network_tracker:
-            self.nwbfile, self.io, self.client = read_hdf5_pynwb_lindi(rfs=https_url)
         return network_tracker.asv_network_statistics
 
 

--- a/src/nwb_benchmarks/benchmarks/time_download_lindi.py
+++ b/src/nwb_benchmarks/benchmarks/time_download_lindi.py
@@ -6,6 +6,7 @@ from nwb_benchmarks.core import BaseBenchmark, download_file
 
 from .params_remote_file_reading import lindi_remote_rfs_parameter_cases
 
+
 class LindiDownloadBenchmark(BaseBenchmark):
     """
     Time the download of a remote LINDI JSON file.

--- a/src/nwb_benchmarks/benchmarks/time_download_lindi.py
+++ b/src/nwb_benchmarks/benchmarks/time_download_lindi.py
@@ -1,0 +1,24 @@
+"""Basic benchmarks for timing download of a remote LINDI JSON file."""
+
+import os
+
+from nwb_benchmarks.core import BaseBenchmark, download_file
+
+from .params_remote_file_reading import lindi_remote_rfs_parameter_cases
+
+class LindiDownloadBenchmark(BaseBenchmark):
+    """
+    Time the download of a remote LINDI JSON file.
+    """
+
+    parameter_cases = lindi_remote_rfs_parameter_cases
+
+    def setup(self, https_url: str):
+        self.lindi_file = os.path.basename(https_url) + ".lindi.json"
+
+    def teardown(self, https_url: str):
+        if os.path.exists(self.lindi_file):
+            os.remove(self.lindi_file)
+
+    def time_download(self, https_url: str):
+        download_file(url=https_url, local_path=self.lindi_file)

--- a/src/nwb_benchmarks/benchmarks/time_download_lindi.py
+++ b/src/nwb_benchmarks/benchmarks/time_download_lindi.py
@@ -16,6 +16,7 @@ class LindiDownloadBenchmark(BaseBenchmark):
 
     def setup(self, https_url: str):
         self.lindi_file = os.path.basename(https_url) + ".lindi.json"
+        self.teardown(https_url=https_url)
 
     def teardown(self, https_url: str):
         if os.path.exists(self.lindi_file):

--- a/src/nwb_benchmarks/benchmarks/time_remote_file_reading.py
+++ b/src/nwb_benchmarks/benchmarks/time_remote_file_reading.py
@@ -176,7 +176,7 @@ class LindiLocalJSONFileReadBenchmark(BaseBenchmark):
         """Download the LINDI JSON file."""
         self.lindi_file = os.path.basename(https_url) + ".lindi.json"
         self.teardown(https_url=https_url)
-        download_file(https_url=https_url, local_path=self.lindi_file)
+        download_file(url=https_url, local_path=self.lindi_file)
 
     def teardown(self, https_url: str):
         """Delete the LINDI JSON file if it exists."""

--- a/src/nwb_benchmarks/benchmarks/time_remote_file_reading.py
+++ b/src/nwb_benchmarks/benchmarks/time_remote_file_reading.py
@@ -192,27 +192,6 @@ class LindiLocalJSONFileReadBenchmark(BaseBenchmark):
         self.nwbfile, self.io, self.client = read_hdf5_pynwb_lindi(rfs=self.lindi_file)
 
 
-class LindiRemoteJSONFileReadBenchmark(BaseBenchmark):
-    """
-    Time the read of remote HDF5 NWB files by reading the remote LINDI JSON files using lindi and h5py or pynwb.
-
-    Note: When LINDI is pointed to a remote JSON, it starts by downloading it, so the time should not be that different
-    from the time to download the remote JSON and load the local JSON.
-
-    Note: in all cases, store the in-memory objects to avoid timing garbage collection steps.
-    """
-
-    parameter_cases = lindi_remote_rfs_parameter_cases
-
-    def time_read_lindi_h5py(self, https_url: str):
-        """Read a remote HDF5 file with h5py using lindi with the remote LINDI JSON file."""
-        self.client = read_hdf5_h5py_lindi(rfs=https_url)
-
-    def time_read_lindi_pynwb(self, https_url: str):
-        """Read a remote HDF5 NWB file with pynwb using lindi with the remote LINDI JSON file."""
-        self.nwbfile, self.io, self.client = read_hdf5_pynwb_lindi(rfs=https_url)
-
-
 class ZarrZarrPythonFileReadBenchmark(BaseBenchmark):
     """
     Time the read of remote Zarr files with Zarr-Python only (not using PyNWB)


### PR DESCRIPTION
Addresses comments from video call. Benchmarking reading of a remote LINDI file is not necessary because the first thing it does is download the LINDI file to a temporary directory. So just benchmark the download. We can add that to the local read time.