### PR TITLE
Refactor parsing of network capture file

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -14,7 +14,7 @@
     "html_dir": ".asv/html",
 
     // These are surprisingly slow operations; the timeout must be extended
-    "default_benchmark_timeout": 1800,
+    "default_benchmark_timeout": 3600,
 
     // `asv` will cache results of the recent builds in each
     // environment, making them faster to install next time.  This is

--- a/src/nwb_benchmarks/core/_network_statistics.py
+++ b/src/nwb_benchmarks/core/_network_statistics.py
@@ -1,8 +1,9 @@
 """Class for summary and display of basic network statistics."""
 
-from typing import Dict, Literal, Union
+import time
+from typing import Dict, Union
 
-import numpy as np
+import pyshark
 
 from ._capture_connections import CaptureConnections
 
@@ -11,129 +12,103 @@ class NetworkStatistics:
     """Compute basic statistics about network packets captures with tshark/pyshark."""
 
     @staticmethod
-    def total_transfer_in_number_of_packets(packets: list) -> int:
-        """Total number of packets."""
-        return len(packets)
-
-    @staticmethod
-    def total_traffic_in_number_of_web_packets(packets: list) -> list:
+    def compute_statistics(capture_file_path, pid_connections: list) -> Dict[str, Union[int, float]]:
         """
-        Get all HTTP and HTTPS packets from the packets captured.
+        Compute network statistics by streaming through packets without storing them all in memory.
 
         Parameters
         ----------
-        packet :
-            Raw packet from a pcap file.
+        capture_file_path : pathlib.Path
+            Path to the capture file to process
+        pid_connections : list
+            List of connection tuples (src_port, dst_port) to filter packets for
 
         Returns
         -------
-        Specific packet details.
+        Dict[str, Union[int, float]]
+            Dictionary containing all computed statistics
         """
-        web_packets = [
-            packet
-            for packet in packets
-            if hasattr(packet, "tcp") and packet[packet.transport_layer].dstport in ["80", "443"]
-        ]
-        return web_packets
 
-    @staticmethod
-    def total_transfer_time_in_seconds(packets: list) -> float:
-        """Sum of all time_delta's between packets."""
-        return float(np.sum([float(packet.tcp.Timestamps.time_delta) for packet in packets]))
+        local_addresses = CaptureConnections.get_local_addresses()
 
-    @staticmethod
-    def amount_downloaded_in_number_of_packets(packets: list, local_addresses: list = None) -> int:
-        """Total number of packets downloaded."""
-        if local_addresses is None:
-            local_addresses = CaptureConnections.get_local_addresses()
-        downloaded = [
-            packet
-            for packet in packets  # check all packets
-            if packet.ip.src not in local_addresses  # the source address is not ours so it's download
-        ]
-        return len(downloaded)
-
-    @staticmethod
-    def amount_uploaded_in_number_of_packets(packets: list, local_addresses: list = None) -> int:
-        """Total number of packets uploaded (e.g., HTTP requests)."""
-        if local_addresses is None:
-            local_addresses = CaptureConnections.get_local_addresses()
-        uploaded = [
-            packet
-            for packet in packets  # check all packets
-            if packet.ip.src in local_addresses  # the source address is ours so it's upload
-        ]
-        return len(uploaded)
-
-    @staticmethod
-    def total_transfer_in_bytes(packets: list) -> int:
-        """Total number of bytes in the packets."""
-        total_transfer_in_bytes = np.sum([len(packet) for packet in packets])
-        return int(total_transfer_in_bytes)
-
-    @staticmethod
-    def amount_downloaded_in_bytes(packets: list, local_addresses: list = None) -> int:
-        """Total number of bytes from downloaded packets."""
-        if local_addresses is None:
-            local_addresses = CaptureConnections.get_local_addresses()
-        amount_downloaded_in_bytes = np.sum(
-            [
-                len(packet)  # size of packet in bytes
-                for packet in packets  # check all packets
-                if packet.ip.src not in local_addresses  # the source address is not ours so it's download
-            ]
-        )
-        return int(amount_downloaded_in_bytes)
-
-    @staticmethod
-    def amount_uploaded_in_bytes(packets: list, local_addresses: list = None) -> int:
-        """Total number of bytes from uploaded packets."""
-        if local_addresses is None:
-            local_addresses = CaptureConnections.get_local_addresses()
-        amount_uploaded_in_bytes = np.sum(
-            [
-                len(packet)  # size of packet in bytes
-                for packet in packets  # check all packets
-                if packet.ip.src in local_addresses  # the source address is ours so it's upload
-            ]
-        )
-        return int(amount_uploaded_in_bytes)
-
-    @staticmethod
-    def bytes_to_str(size_in_bytes: int, convention: Literal["B", "iB"] = "iB") -> str:
-        """Format the size in bytes as a human-readable string."""
-        factor = 1024 if convention == "iB" else 1000
-        for unit in ["", "K", "M", "G", "T", "P"]:
-            if size_in_bytes < factor:
-                return f"{bytes:.2f}{unit}{convention}"
-            size_in_bytes /= factor
-
-    @classmethod
-    def get_statistics(cls, packets: list, local_addresses: list = None) -> Dict[str, Union[int, float]]:
-        """Calculate all the statistics and return them as a dictionary."""
-        if local_addresses is None:
-            local_addresses = CaptureConnections.get_local_addresses()
-        statistics = {
-            "amount_downloaded_in_bytes": cls.amount_downloaded_in_bytes(
-                packets=packets, local_addresses=local_addresses
-            ),
-            "amount_uploaded_in_bytes": cls.amount_uploaded_in_bytes(packets=packets, local_addresses=local_addresses),
-            "total_transfer_in_bytes": cls.total_transfer_in_bytes(packets=packets),
-            "amount_downloaded_in_number_of_packets": cls.amount_downloaded_in_number_of_packets(
-                packets=packets, local_addresses=local_addresses
-            ),
-            "amount_uploaded_in_number_of_packets": cls.amount_uploaded_in_number_of_packets(
-                packets=packets, local_addresses=local_addresses
-            ),
-            "total_transfer_in_number_of_packets": cls.total_transfer_in_number_of_packets(packets=packets),
-            "total_traffic_in_number_of_web_packets": len(cls.total_traffic_in_number_of_web_packets(packets)),
-            "total_transfer_time_in_seconds": cls.total_transfer_time_in_seconds(packets=packets),
+        # Initialize counters
+        stats = {
+            "total_transfer_in_number_of_packets": 0,
+            "total_traffic_in_number_of_web_packets": 0,
+            "amount_downloaded_in_number_of_packets": 0,
+            "amount_uploaded_in_number_of_packets": 0,
+            "total_transfer_in_bytes": 0,
+            "amount_downloaded_in_bytes": 0,
+            "amount_uploaded_in_bytes": 0,
+            "total_transfer_time_in_seconds": 0.0,
         }
-        return statistics
 
-    @classmethod
-    def print_statistics(cls, packets: list, local_addresses: list = None):
-        """Print all the statistics."""
-        statistics = cls.get_statistics(packets=packets, local_addresses=local_addresses)
-        for key, value in statistics.items():
-            print(f"{key}: {value}")
+        try:
+            capture_file_size_mb = capture_file_path.stat().st_size / (1024 * 1024)
+            print(f"Processing packets from capture file ({capture_file_size_mb:.0f} MB) with streaming...")
+            start_time = time.time()
+
+            cap = pyshark.FileCapture(capture_file_path, use_json=True)
+
+            # Process packets one by one
+            packet_count = 0
+            for packet in cap:
+                packet_count += 1
+
+                # Filter for PID connections if specified
+                is_pid_packet = False
+                if hasattr(packet, "tcp"):
+                    ports = int(str(packet.tcp.srcport)), int(str(packet.tcp.dstport))
+                    if ports in pid_connections:
+                        is_pid_packet = True
+
+                if not is_pid_packet:
+                    continue
+
+                # Update packet count
+                stats["total_transfer_in_number_of_packets"] += 1
+
+                # Check if it's a web packet (HTTP/HTTPS)
+                if hasattr(packet, "tcp") and packet[packet.transport_layer].dstport in ["80", "443"]:
+                    stats["total_traffic_in_number_of_web_packets"] += 1
+
+                # Calculate bytes
+                packet_size = len(packet)
+                stats["total_transfer_in_bytes"] += packet_size
+
+                # Determine if upload or download
+                if hasattr(packet, "ip"):
+                    if packet.ip.src not in local_addresses:  # Download
+                        stats["amount_downloaded_in_number_of_packets"] += 1
+                        stats["amount_downloaded_in_bytes"] += packet_size
+                    else:  # Upload
+                        stats["amount_uploaded_in_number_of_packets"] += 1
+                        stats["amount_uploaded_in_bytes"] += packet_size
+
+                # Add time delta if available
+                if (
+                    hasattr(packet, "tcp")
+                    and hasattr(packet.tcp, "Timestamps")
+                    and hasattr(packet.tcp.Timestamps, "time_delta")
+                ):
+                    stats["total_transfer_time_in_seconds"] += float(packet.tcp.Timestamps.time_delta)
+
+                # Print progress every 100000 packets
+                if packet_count % 100000 == 0:
+                    print(
+                        f"Processed {packet_count} packets, {stats['total_transfer_in_number_of_packets']} "
+                        "relevant packets found..."
+                    )
+
+            cap.close()
+            del cap
+
+            end_time = time.time()
+            print(f"Packets processed: {packet_count}")
+            print(f"Relevant packets found: {stats['total_transfer_in_number_of_packets']}")
+            print(f"Time taken to process packets: {end_time - start_time:.1f} seconds")
+
+        except Exception as e:
+            print("Error processing packets:", e)
+
+        return stats

--- a/src/nwb_benchmarks/setup/__init__.py
+++ b/src/nwb_benchmarks/setup/__init__.py
@@ -6,6 +6,7 @@ from ._config import (
     get_benchmarks_home_directory,
     get_cache_directory,
     get_temporary_directory,
+    get_temporary_file,
     read_config,
     set_cache_directory,
 )
@@ -23,6 +24,7 @@ __all__ = [
     "get_benchmarks_config_file_path",
     "get_benchmarks_home_directory",
     "get_temporary_directory",
+    "get_temporary_file",
     "generate_machine_file",
     "generate_human_readable_machine_name",
     "read_config",

--- a/src/nwb_benchmarks/setup/_config.py
+++ b/src/nwb_benchmarks/setup/_config.py
@@ -107,6 +107,7 @@ def get_temporary_file() -> pathlib.Path:
     """
     cache_directory = get_cache_directory()
     temporary_file = tempfile.NamedTemporaryFile(delete=False, dir=cache_directory)
+    temporary_file.close()
     return pathlib.Path(temporary_file.name)
 
 

--- a/src/nwb_benchmarks/setup/_config.py
+++ b/src/nwb_benchmarks/setup/_config.py
@@ -96,6 +96,20 @@ def get_temporary_directory() -> pathlib.Path:
     return temporary_directory
 
 
+def get_temporary_file() -> pathlib.Path:
+    """
+    Get a temporary file for NWB Benchmarks.
+
+    Returns
+    -------
+    pathlib.Path
+        The temporary file path.
+    """
+    cache_directory = get_cache_directory()
+    temporary_file = tempfile.NamedTemporaryFile(delete=False, dir=cache_directory)
+    return pathlib.Path(temporary_file.name)
+
+
 def clean_cache(ignore_errors: bool = False) -> None:
     """
     Clean the cache directory for NWB Benchmarks.
@@ -104,4 +118,7 @@ def clean_cache(ignore_errors: bool = False) -> None:
     """
     cache_directory = get_cache_directory()
     for path in cache_directory.iterdir():
-        shutil.rmtree(path=path, ignore_errors=ignore_errors)
+        if path.is_dir():
+            shutil.rmtree(path=path, ignore_errors=ignore_errors)
+        else:
+            path.unlink(missing_ok=True)


### PR DESCRIPTION
- Increase benchmark timeout to 1 hour
- Major refactor of how the capture file is parsed and stats are computed. Instead of storing all the packets in a giant list, filtering the list, and computing statistics on that list, we now read the packets one by one from the capture file, accumulate statistics as we read, and then discard the packet. This drops memory usage to basically nothing.