### PR TITLE
Run asv command once and always log to file

### DIFF
--- a/src/nwb_benchmarks/command_line_interface.py
+++ b/src/nwb_benchmarks/command_line_interface.py
@@ -107,7 +107,6 @@ def main() -> None:
             asv_process.stdout.close()
             asv_process.wait()
 
-
             # Consider the raw ASV output as 'intermediate' and perform additional parsing
             globbed_json_file_paths = [
                 path


### PR DESCRIPTION
A recent change split debug mode and non-debug mode for calling ASV. The non-debug mode called the asv command twice. It should call it only once. And I don't think we need to split debug vs non-debug mode. Debug mode currently prints the asv output to both stdout and a log file. I think we should also do that in non-debug mode.